### PR TITLE
 feat(parser): Ignore hex literals

### DIFF
--- a/benches/file.rs
+++ b/benches/file.rs
@@ -17,6 +17,7 @@ fn process_empty(b: &mut test::Bencher) {
         typos::process_file(
             sample_path.path(),
             &corrections,
+            true,
             typos::report::print_silent,
         )
     });
@@ -35,6 +36,7 @@ fn process_no_tokens(b: &mut test::Bencher) {
         typos::process_file(
             sample_path.path(),
             &corrections,
+            true,
             typos::report::print_silent,
         )
     });
@@ -53,6 +55,7 @@ fn process_single_token(b: &mut test::Bencher) {
         typos::process_file(
             sample_path.path(),
             &corrections,
+            true,
             typos::report::print_silent,
         )
     });
@@ -71,6 +74,7 @@ fn process_sherlock(b: &mut test::Bencher) {
         typos::process_file(
             sample_path.path(),
             &corrections,
+            true,
             typos::report::print_silent,
         )
     });
@@ -89,6 +93,7 @@ fn process_code(b: &mut test::Bencher) {
         typos::process_file(
             sample_path.path(),
             &corrections,
+            true,
             typos::report::print_silent,
         )
     });
@@ -107,6 +112,7 @@ fn process_corpus(b: &mut test::Bencher) {
         typos::process_file(
             sample_path.path(),
             &corrections,
+            true,
             typos::report::print_silent,
         )
     });

--- a/docs/about.md
+++ b/docs/about.md
@@ -40,7 +40,7 @@ Whitelist: A confidence rating is given for how close a word is to one in the wh
 | Per-Lang Dict  | No ([#14][def-14])    | No                              | ?                               | No          | Yes         |
 | CamelCase      | Yes                   | No                              | ?                               | No          | Yes         |
 | snake_case     | Yes                   | No                              | ?                               | No          | Yes         |
-| Ignore Hex     | No ([#19][def-19])    | No                              | ?                               | No          | Yes         |
+| Ignore Hex     | Yes                   | No                              | ?                               | No          | Yes         |
 | C-Escapes      | No ([#20][def-3])     | No                              | ?                               | No          | Yes         |
 | Encodings      | UTF-8 ([#17][def-17]) | UTF-8                           | ?                               | Auto        | Auto        |
 | Whole-project  | Yes                   | Yes                             | Yes                             | Yes         | No          |
@@ -59,6 +59,5 @@ Whitelist: A confidence rating is given for how close a word is to one in the wh
 [def-14]: https://github.com/epage/typos/issues/14
 [def-17]: https://github.com/epage/typos/issues/17
 [def-18]: https://github.com/epage/typos/issues/18
-[def-19]: https://github.com/epage/typos/issues/19
 [def-24]: https://github.com/epage/typos/issues/24
 [def-3]: https://github.com/epage/typos/issues/3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,8 @@ pub fn process_file(
 fn is_hex(ident: &str) -> bool {
     lazy_static::lazy_static! {
         // `_`: number literal separator in Rust and other languages
-        static ref HEX: regex::Regex = regex::Regex::new(r#"^0[xX][0-9a-fA-F_]+$"#).unwrap();
+        // `'`: number literal separator in C++
+        static ref HEX: regex::Regex = regex::Regex::new(r#"^0[xX][0-9a-fA-F_']+$"#).unwrap();
     }
     HEX.is_match(ident)
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -42,7 +42,7 @@ impl<'t> Identifier<'t> {
         lazy_static::lazy_static! {
             // Getting false positives for this lint
             #[allow(clippy::invalid_regex)]
-            static ref SPLIT: regex::bytes::Regex = regex::bytes::Regex::new(r#"\b(\p{Alphabetic}|\d|_)+\b"#).unwrap();
+            static ref SPLIT: regex::bytes::Regex = regex::bytes::Regex::new(r#"\b(\p{Alphabetic}|\d|_|')+\b"#).unwrap();
         }
         SPLIT.find_iter(content).filter_map(|m| {
             let s = std::str::from_utf8(m.as_bytes()).ok();


### PR DESCRIPTION
Trying to avoid accidentally correcting something that looks like a word
inside a hex number, like `0xBEAF`.

Fixes #19